### PR TITLE
feat: rename `toJson` to `toJSON`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const chainId = new ChainId({ namespace: "eip155", reference: "1" });
 chainId.toString();
 // "eip155:1"
 
-chainId.toJson();
+chainId.toJSON();
 // { namespace: "eip155", reference: "1" }
 ```
 
@@ -68,7 +68,7 @@ const accountId = new AccountId({
 accountId.toString();
 // "eip155:1:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"
 
-accountId.toJson();
+accountId.toJSON();
 // { address: "0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb", chainId: { namespace: "eip155", reference: "1" } }
 ```
 
@@ -132,7 +132,7 @@ const assetId = new AssetId({
 assetId.toString();
 // "eip155:1/erc721:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb/1"
 
-assetId.toJson();
+assetId.toJSON();
 // {
 //   chainId: { namespace: "eip155", reference: "1" },
 //   assetName: { namespace: "erc721", reference: "0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb" },
@@ -207,7 +207,7 @@ const assetType = new AssetType({
 assetType.toString();
 // "eip155:1/erc721:0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb"
 
-assetType.toJson();
+assetType.toJSON();
 // {
 //   chainId: { namespace: "eip155", reference: "1" },
 //   assetName: { namespace: "erc721", reference: "0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb" },

--- a/src/account.ts
+++ b/src/account.ts
@@ -23,13 +23,13 @@ export class AccountId {
       this.spec
     );
     const chainId = new ChainId({ namespace, reference });
-    return new AccountId({ chainId, address }).toJson();
+    return new AccountId({ chainId, address }).toJSON();
   }
 
   public static format(params: AccountIdParams): string {
     const chainId = new ChainId(params.chainId);
     const splitParams: AccountIdSplitParams = {
-      ...chainId.toJson(),
+      ...chainId.toJSON(),
       address: params.address,
     };
     return joinParams(splitParams as any, this.spec);
@@ -48,12 +48,12 @@ export class AccountId {
   }
 
   public toString(): string {
-    return AccountId.format(this.toJson());
+    return AccountId.format(this.toJSON());
   }
 
-  public toJson(): AccountIdParams {
+  public toJSON(): AccountIdParams {
     return {
-      chainId: this.chainId.toJson(),
+      chainId: this.chainId.toJSON(),
       address: this.address,
     };
   }

--- a/src/assetId.ts
+++ b/src/assetId.ts
@@ -17,7 +17,7 @@ export class AssetId {
     if (!isValidId(id, this.spec)) {
       throw new Error(`Invalid ${this.spec.name} provided: ${id}`);
     }
-    return new AssetId(getParams<AssetIdParams>(id, this.spec)).toJson();
+    return new AssetId(getParams<AssetIdParams>(id, this.spec)).toJSON();
   }
 
   public static format(params: AssetIdParams): string {
@@ -39,13 +39,13 @@ export class AssetId {
   }
 
   public toString(): string {
-    return AssetId.format(this.toJson());
+    return AssetId.format(this.toJSON());
   }
 
-  public toJson(): AssetIdParams {
+  public toJSON(): AssetIdParams {
     return {
-      chainId: this.chainId.toJson(),
-      assetName: this.assetName.toJson(),
+      chainId: this.chainId.toJSON(),
+      assetName: this.assetName.toJSON(),
       tokenId: this.tokenId,
     };
   }

--- a/src/assetName.ts
+++ b/src/assetName.ts
@@ -14,7 +14,7 @@ export class AssetName {
     if (!isValidId(id, this.spec)) {
       throw new Error(`Invalid ${this.spec.name} provided: ${id}`);
     }
-    return new AssetName(getParams<AssetNameParams>(id, this.spec)).toJson();
+    return new AssetName(getParams<AssetNameParams>(id, this.spec)).toJSON();
   }
 
   public static format(params: AssetNameParams): string {
@@ -34,10 +34,10 @@ export class AssetName {
   }
 
   public toString(): string {
-    return AssetName.format(this.toJson());
+    return AssetName.format(this.toJSON());
   }
 
-  public toJson(): AssetNameParams {
+  public toJSON(): AssetNameParams {
     return {
       namespace: this.namespace,
       reference: this.reference,

--- a/src/assetType.ts
+++ b/src/assetType.ts
@@ -16,7 +16,7 @@ export class AssetType {
     if (!isValidId(id, this.spec)) {
       throw new Error(`Invalid ${this.spec.name} provided: ${id}`);
     }
-    return new AssetType(getParams<AssetTypeParams>(id, this.spec)).toJson();
+    return new AssetType(getParams<AssetTypeParams>(id, this.spec)).toJSON();
   }
 
   public static format(params: AssetTypeParams): string {
@@ -36,12 +36,12 @@ export class AssetType {
   }
 
   public toString(): string {
-    return AssetType.format(this.toJson());
+    return AssetType.format(this.toJSON());
   }
 
-  public toJson(): AssetTypeParams {
+  public toJSON(): AssetTypeParams {
     return {
-      chainId: this.chainId.toJson(),
+      chainId: this.chainId.toJSON(),
       assetName: this.assetName,
     };
   }

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -14,7 +14,7 @@ export class ChainId {
     if (!isValidId(id, this.spec)) {
       throw new Error(`Invalid ${this.spec.name} provided: ${id}`);
     }
-    return new ChainId(getParams<ChainIdParams>(id, this.spec)).toJson();
+    return new ChainId(getParams<ChainIdParams>(id, this.spec)).toJSON();
   }
 
   public static format(params: ChainIdParams): string {
@@ -34,10 +34,10 @@ export class ChainId {
   }
 
   public toString(): string {
-    return ChainId.format(this.toJson());
+    return ChainId.format(this.toJSON());
   }
 
-  public toJson(): ChainIdParams {
+  public toJSON(): ChainIdParams {
     return {
       namespace: this.namespace,
       reference: this.reference,

--- a/test/account.test.ts
+++ b/test/account.test.ts
@@ -6,7 +6,7 @@ function assertAccountIdInterface(result: AccountId) {
   expect(result.chainId.toString()).toEqual(data.CHAIN_ID_STRING);
   expect(result.address).toEqual(data.ACCOUNT_ID_ADDRESS);
   expect(result.toString()).toEqual(data.ACCOUNT_ID_STRING);
-  expect(result.toJson()).toEqual(data.ACCOUNT_ID_NESTED_PARAMS);
+  expect(result.toJSON()).toEqual(data.ACCOUNT_ID_NESTED_PARAMS);
 }
 
 describe("AccountId", () => {
@@ -33,5 +33,12 @@ describe("AccountId", () => {
   it("should instantiate from nested params", async () => {
     const result = new AccountId(data.ACCOUNT_ID_NESTED_PARAMS);
     assertAccountIdInterface(result);
+  });
+
+  it("should support JSON.stringify", async () => {
+    const result = new AccountId(data.ACCOUNT_ID_PARAMS);
+    const str = JSON.stringify(result);
+    const json = JSON.parse(str);
+    assertAccountIdInterface(new AccountId(json));
   });
 });

--- a/test/assetId.test.ts
+++ b/test/assetId.test.ts
@@ -7,7 +7,7 @@ function assertInterface(result: AssetId) {
   expect(result.assetName.toString()).toEqual(data.ASSET_NAME_STRING);
   expect(result.tokenId).toEqual(data.TOKEN_ID);
   expect(result.toString()).toEqual(data.ASSET_ID_STRING);
-  expect(result.toJson()).toEqual(data.ASSET_ID_NESTED_PARAMS);
+  expect(result.toJSON()).toEqual(data.ASSET_ID_NESTED_PARAMS);
 }
 
 describe("AssetId", () => {
@@ -34,5 +34,12 @@ describe("AssetId", () => {
   it("should instantiate from nested params", async () => {
     const result = new AssetId(data.ASSET_ID_NESTED_PARAMS);
     assertInterface(result);
+  });
+
+  it("should support JSON.stringify", async () => {
+    const result = new AssetId(data.ASSET_ID_PARAMS);
+    const str = JSON.stringify(result);
+    const json = JSON.parse(str);
+    assertInterface(new AssetId(json));
   });
 });

--- a/test/assetName.test.ts
+++ b/test/assetName.test.ts
@@ -6,7 +6,7 @@ function assertInterface(result: AssetName) {
   expect(result.namespace).toEqual(data.ASSET_NAMESPACE);
   expect(result.reference).toEqual(data.ASSET_REFERENCE);
   expect(result.toString()).toEqual(data.ASSET_NAME_STRING);
-  expect(result.toJson()).toEqual(data.ASSET_NAME_PARAMS);
+  expect(result.toJSON()).toEqual(data.ASSET_NAME_PARAMS);
 }
 
 describe("AssetName", () => {
@@ -33,5 +33,12 @@ describe("AssetName", () => {
   it("should instantiate from nested params", async () => {
     const result = new AssetName(data.ASSET_NAME_PARAMS);
     assertInterface(result);
+  });
+
+  it("should support JSON.stringify", async () => {
+    const result = new AssetName(data.ASSET_NAME_PARAMS);
+    const str = JSON.stringify(result);
+    const json = JSON.parse(str);
+    assertInterface(new AssetName(json));
   });
 });

--- a/test/assetType.test.ts
+++ b/test/assetType.test.ts
@@ -6,7 +6,7 @@ function assertInterface(result: AssetType) {
   expect(result.chainId.toString()).toEqual(data.CHAIN_ID_STRING);
   expect(result.assetName.toString()).toEqual(data.ASSET_NAME_STRING);
   expect(result.toString()).toEqual(data.ASSET_TYPE_STRING);
-  expect(result.toJson()).toEqual(data.ASSET_TYPE_NESTED_PARAMS);
+  expect(result.toJSON()).toEqual(data.ASSET_TYPE_NESTED_PARAMS);
 }
 
 describe("AssetType", () => {
@@ -33,5 +33,12 @@ describe("AssetType", () => {
   it("should instantiate from nested params", async () => {
     const result = new AssetType(data.ASSET_TYPE_NESTED_PARAMS);
     assertInterface(result);
+  });
+
+  it("should support JSON.stringify", async () => {
+    const result = new AssetType(data.ASSET_TYPE_PARAMS);
+    const str = JSON.stringify(result);
+    const json = JSON.parse(str);
+    assertInterface(new AssetType(json));
   });
 });

--- a/test/chain.test.ts
+++ b/test/chain.test.ts
@@ -6,7 +6,7 @@ function assertChainIdInterface(result: ChainId) {
   expect(result.namespace).toEqual(data.CHAIN_ID_NAMESPACE);
   expect(result.reference).toEqual(data.CHAIN_ID_REFERENCE);
   expect(result.toString()).toEqual(data.CHAIN_ID_STRING);
-  expect(result.toJson()).toEqual(data.CHAIN_ID_PARAMS);
+  expect(result.toJSON()).toEqual(data.CHAIN_ID_PARAMS);
 }
 
 describe("ChainId", () => {
@@ -28,5 +28,12 @@ describe("ChainId", () => {
   it("should instantiate from string", async () => {
     const result = new ChainId(data.CHAIN_ID_STRING);
     assertChainIdInterface(result);
+  });
+
+  it("should support JSON.stringify", async () => {
+    const result = new ChainId(data.CHAIN_ID_STRING);
+    const str = JSON.stringify(result);
+    const json = JSON.parse(str);
+    assertChainIdInterface(new ChainId(json));
   });
 });


### PR DESCRIPTION
This PR is to make CAIP objects compatiable with JSON.stringify that honors `toJSON`.
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>