### PR TITLE
fix: update exports to include types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "unpkg": "dist/index.umd.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }


### PR DESCRIPTION
Looks like the types declaration is missing from the exports. This can cause build failures in some scenarios.